### PR TITLE
ListError preservating created itemErrors

### DIFF
--- a/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
+++ b/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
@@ -23,13 +23,14 @@ public class ListErrorImpl implements ListError {
 	}
 
 	@Override
-	public FormError itemError(int index) {		
-		FormError itemError = this.itemErrors.get(index);
-		if (itemError == null) {
-			itemError = new FormErrorImpl(this.target.get(index));
-			this.itemErrors.add(index, itemError);
+	public FormError itemError(int index) {
+		if (this.itemErrors.size() > index) {
+			return this.itemErrors.get(index);
 		}
+		FormError itemError = new FormErrorImpl(this.target.get(index));
+		this.itemErrors.add(index, itemError);
 		return itemError;
+
 	}
 	
 	@Override

--- a/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
+++ b/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
@@ -30,7 +30,6 @@ public class ListErrorImpl implements ListError {
 		FormError itemError = new FormErrorImpl(this.target.get(index));
 		this.itemErrors.add(index, itemError);
 		return itemError;
-
 	}
 	
 	@Override

--- a/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
+++ b/src/main/java/br/ufsc/bridge/platform/validation/form/errors/ListErrorImpl.java
@@ -5,14 +5,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("rawtypes")
 public class ListErrorImpl implements ListError {
 
 	private static final long serialVersionUID = 6107994429283159738L;
 
 	private transient List<?> target;
 	private String rootError;
-	private List<ValidationError> itemErrors = new ArrayList<>();
+	private List<FormError> itemErrors = new ArrayList<>();
 
 	public ListErrorImpl(List<?> target) {
 		super();
@@ -23,21 +22,22 @@ public class ListErrorImpl implements ListError {
 		this.rootError = mensagem;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public FormError itemError(int index) {
-		FormErrorImpl itemErrors = new FormErrorImpl(this.target.get(index));
-		this.itemErrors.add(index, itemErrors);
-		return itemErrors;
+	public FormError itemError(int index) {		
+		FormError itemError = this.itemErrors.get(index);
+		if (itemError == null) {
+			itemError = new FormErrorImpl(this.target.get(index));
+			this.itemErrors.add(index, itemError);
+		}
+		return itemError;
 	}
-
-	@SuppressWarnings("unchecked")
+	
 	@Override
 	public boolean isValid() {
 		boolean valid = this.rootError == null;
 
 		if (valid) {
-			Iterator<ValidationError> iterator = this.itemErrors.iterator();
+			Iterator<FormError> iterator = this.itemErrors.iterator();
 			while (iterator.hasNext()) {
 				ValidationError validationError = iterator.next();
 				if (validationError instanceof FormErrorImpl) {


### PR DESCRIPTION
Para solucionar a issue #35, modifico o metodo mencionado para realizar a checagem proposta.

Como adaptação ao novo cenário desabstraio a lista _itemErrors_, que passa a armazenar apenas **FormError**s e não mais **ValidationError**s. Entendi que isso não seria de grande impacto, visto que a única maneira de inserir itens na lista (até então) é através do método foco dessa evolução.
