### PR TITLE
Validation of maxLength for richText

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>metafy</artifactId>
             <version>0.1.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthRule.kt
+++ b/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthRule.kt
@@ -9,7 +9,7 @@ class RichTextMaxLengthRule(private val maxLength: Int) : Rule<String?> {
     private val htmlTagPattern = Regex("\\<.*?\\>|\n")
 
     override fun validate(value: String?): String? {
-        var text = StringEscapeUtils.unescapeHtml4(value?.replace(htmlTagPattern, ""))
-        return if (!Util.isEmpty(text) && text?.length!! > maxLength!!) "Deve possuir no máximo $maxLength caracteres" else null
+        val text = StringEscapeUtils.unescapeHtml4(value?.replace(htmlTagPattern, ""))
+        return if (!Util.isEmpty(text) && text?.length!! > maxLength) "Deve possuir no máximo $maxLength caracteres" else null
     }
 }

--- a/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthRule.kt
+++ b/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthRule.kt
@@ -1,0 +1,15 @@
+package br.ufsc.bridge.platform.validation.rules
+
+import br.ufsc.bridge.platform.validation.engine.Rule
+import br.ufsc.bridge.platform.validation.util.Util
+import org.apache.commons.text.StringEscapeUtils
+
+class RichTextMaxLengthRule(private val maxLength: Int) : Rule<String?> {
+
+    private val htmlTagPattern = Regex("\\<.*?\\>|\n")
+
+    override fun validate(value: String?): String? {
+        var text = StringEscapeUtils.unescapeHtml4(value?.replace(htmlTagPattern, ""))
+        return if (!Util.isEmpty(text) && text?.length!! > maxLength!!) "Deve possuir no máximo $maxLength caracteres" else null
+    }
+}

--- a/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/Rules.kt
+++ b/src/main/kotlin/br/ufsc/bridge/platform/validation/rules/Rules.kt
@@ -62,4 +62,9 @@ object Rules {
     fun match(regex: String): Rule<String?> {
         return MatchRule(regex)
     }
+
+    @JvmStatic
+    fun richTextMaxLength(maxLength: Int): RichTextMaxLengthRule {
+        return RichTextMaxLengthRule(maxLength)
+    }
 }

--- a/src/test/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthTest.kt
+++ b/src/test/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthTest.kt
@@ -2,18 +2,24 @@ package br.ufsc.bridge.platform.validation.rules
 
 import br.ufsc.bridge.platform.validation.ValidationTest
 import br.ufsc.bridge.platform.validation.rules.Rules.richTextMaxLength
-import org.junit.Assert
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class RichTextMaxLengthTest : ValidationTest() {
     @Test
-    fun empty() {
-        Assert.assertNull("Atributo null é válido", validate(null, richTextMaxLength(10)))
+    fun `Atributo null eh valido`() {
+        assertNull(validate(null, richTextMaxLength(10)))
     }
 
     @Test
-    fun min() {
-        Assert.assertNotNull("Atributo com length <strong>maior</strong> que o max é inválido", validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(20)))
-        Assert.assertNull("Atributo com length menor que o max é válido", validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(25)))
+    fun `Atributo com length maior que o max eh invalido`() {
+        assertNotNull(validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(20)))
+
+    }
+
+    @Test
+    fun `Atributo com length menor que o max eh valido`(){
+        assertNull(validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(25)))
     }
 }

--- a/src/test/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthTest.kt
+++ b/src/test/kotlin/br/ufsc/bridge/platform/validation/rules/RichTextMaxLengthTest.kt
@@ -1,0 +1,19 @@
+package br.ufsc.bridge.platform.validation.rules
+
+import br.ufsc.bridge.platform.validation.ValidationTest
+import br.ufsc.bridge.platform.validation.rules.Rules.richTextMaxLength
+import org.junit.Assert
+import org.junit.jupiter.api.Test
+
+class RichTextMaxLengthTest : ValidationTest() {
+    @Test
+    fun empty() {
+        Assert.assertNull("Atributo null é válido", validate(null, richTextMaxLength(10)))
+    }
+
+    @Test
+    fun min() {
+        Assert.assertNotNull("Atributo com length <strong>maior</strong> que o max é inválido", validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(20)))
+        Assert.assertNull("Atributo com length menor que o max é válido", validate("Lorem <em>dolor</em> sit <strong>ipsum</strong>.", richTextMaxLength(25)))
+    }
+}


### PR DESCRIPTION
complemento da issue [#4585](https://github.com/laboratoriobridge/pec/issues/4585)

Criado validação para o texto do componente do richText, removendo as tags HTML da mesma forma que é feito no frontend.