### PR TITLE
Preparação para release de uma 2.0.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,33 +1,32 @@
 name: Java CI with Maven
 
 on:
-  push:
-    branches: master
   pull_request:
-    branches: '*'
+    branches:
+      - '*'
 
 jobs:
   build:
-
+    
     runs-on: ubuntu-latest
-
+    
     steps:
-    - uses: actions/checkout@v2  
-    
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: '8'
-        distribution: 'zulu'
-            
-    - name: Cache local Maven repository
-      uses: actions/cache@v2.1.6
-      with:
-        path: ~/.m2/
-        key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }} 
-    
-    - name: Build with Maven
-      run: mvn clean verify
-
-    - name: Upload codecov report
-      uses: codecov/codecov-action@v1.5.2
+      - uses: actions/checkout@v4
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+      
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+      
+      - name: Build with Maven
+        run: mvn clean verify
+      
+      - name: Upload codecov report
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,16 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-            token: ${{ secrets.RELEASE_TOKEN }}
-
-        
+          token: ${{ secrets.RELEASE_TOKEN }}
+      
+      
       
       - name: Set up JDK, Maven Central credentials and GPG key
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with: # Create the settings.xml with Maven Central credentials and GPG private key
-          java-version: '8'
+          java-version: 17
           distribution: 'zulu'
           server-id: ossrh
           server-username: MAVEN_USERNAME
@@ -29,30 +29,30 @@ jobs:
       
       - name: Configure Git User
         run: |
-            git config user.email "actions@github.com"
-            git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
       
       - name: Prepare the release
         env:
           MVN_RELEASE_GPG_PASSPHRASE: ${{ secrets.MVN_RELEASE_GPG_PASSPHRASE }}
         run: mvn -B release:prepare -Possrh
-  
+      
       - name: Push the release to Maven Central
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MVN_RELEASE_GPG_PASSPHRASE: ${{ secrets.MVN_RELEASE_GPG_PASSPHRASE }}
         run: mvn release:perform -Possrh
-        
+      
       - name: Set up JDK and Nexus credentials
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with: # Will overwrite the settings.xml created for Maven Central
-          java-version: '8'
+          java-version: 17
           distribution: 'zulu'
           server-id: repo-bridge
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
-        
+      
       - name: Push the release to Nexus
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>br.ufsc.bridge</groupId>
@@ -29,8 +30,8 @@
     <properties>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
-        <kotlin.version>1.3.50</kotlin.version>
-        <junit.version>5.5.2</junit.version>
+        <kotlin.version>1.9.22</kotlin.version>
+        <junit.version>5.10.1</junit.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -78,13 +79,13 @@
         <dependency>
             <groupId>br.ufsc.bridge</groupId>
             <artifactId>metafy</artifactId>
-<!--            TODO: gerar release metafy e colocar aqui (versão atual é local para teste local) -->
+            <!--            TODO: gerar release metafy e colocar aqui (versão atual é local para teste local) -->
             <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.11.0</version>
         </dependency>
     </dependencies>
 
@@ -131,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -140,6 +141,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
             </plugin>
 
             <!-- Testes -->
@@ -147,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.1</version>
+                <version>3.2.3</version>
             </plugin>
 
             <!-- Geracao de relatorios de cobertura de codigo -->
@@ -189,7 +193,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -205,7 +209,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -217,7 +221,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -245,7 +249,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -276,7 +280,7 @@
         </profile>
     </profiles>
 
-   <scm>
+    <scm>
         <connection>scm:git:git@github.com:laboratoriobridge/validation.git</connection>
         <url>scm:git:git@github.com:laboratoriobridge/validation.git</url>
         <developerConnection>scm:git:git@github.com:laboratoriobridge/validation.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>br.ufsc.bridge</groupId>
     <artifactId>validation</artifactId>
-    <version>1.4.11-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Bridge Platform - Validation</name>
@@ -79,8 +79,7 @@
         <dependency>
             <groupId>br.ufsc.bridge</groupId>
             <artifactId>metafy</artifactId>
-            <!--            TODO: gerar release metafy e colocar aqui (versão atual é local para teste local) -->
-            <version>1.0.1</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -88,6 +87,17 @@
             <version>1.11.0</version>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>repo-bridge</id>
+            <url>https://repositorio.bridge.ufsc.br/repository/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -224,9 +234,6 @@
                 <version>3.0.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>ossrh</releaseProfiles>
-                    <goals>deploy</goals>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
@@ -235,15 +242,8 @@
     </build>
 
     <profiles>
-        <!-- MAVEN CENTRAL -->
         <profile>
-            <id>ossrh</id>
-            <distributionManagement>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -262,21 +262,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <!-- NEXUS -->
-        <profile>
-            <id>repo-bridge</id>
-            <distributionManagement>
-                <repository>
-                    <id>repo-bridge</id>
-                    <url>${env.NEXUS_PUBLIC_URL}</url>
-                </repository>
-                <snapshotRepository>
-                    <id>repo-bridge</id>
-                    <url>${env.NEXUS_SNAPSHOT_URL}</url>
-                </snapshotRepository>
-            </distributionManagement>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <kotlin.version>1.3.50</kotlin.version>
         <junit.version>5.5.2</junit.version>
 
@@ -78,7 +78,8 @@
         <dependency>
             <groupId>br.ufsc.bridge</groupId>
             <artifactId>metafy</artifactId>
-            <version>0.1.2</version>
+<!--            TODO: gerar release metafy e colocar aqui (versão atual é local para teste local) -->
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -154,7 +155,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.11</version>
                 <configuration>
                     <destFile>${sonar.jacoco.itReportPath}</destFile>
                     <dataFile>${sonar.jacoco.itReportPath}</dataFile>


### PR DESCRIPTION
Recomendo revisar com a opção "hide whitespace" selecionada (https://github.com/laboratoriobridge/validation/pull/72/files?w=1), porque o formatter do bridge fez várias alterações de espaço nos arquivos.

De uma parte mais geral do repositório, fiz o seguinte:

- Criei o branch `main-v2`
- Mudei o nome do branch principal de `master` para `main`
- Deletei branchs antigos out-of-date
- Add rule protection nos branchs `main` e `main-v2`

Com dois branchs, a ideia é a seguinte:

- `main`
  - continuar desenvolvimento da 1.x.x com suporte para java 8, javax e spring 2
- `main-v2`
  - iniciar desenvolvimento da 2.x.x com suporte para java 17, jakarta e spring 3

Nesse PR em específico:

- Atualizei para usar java 17
- Subi a versão de todas as outras bibliotecas
- Tirei os warnings do build da javadoc
- Atualizei action do github (action de release não foi testada)
- Alterei algumas configs do pom que tinham sido adicionadas no #60  para a action de release. Se essa ideia da action de release for retomada, isso terá que ser revisto.

